### PR TITLE
Update skeletonViewer.ts

### DIFF
--- a/packages/dev/core/src/Debug/skeletonViewer.ts
+++ b/packages/dev/core/src/Debug/skeletonViewer.ts
@@ -417,11 +417,12 @@ export class SkeletonViewer {
         options.computeBonesUsingShaders = options.computeBonesUsingShaders ?? true;
         options.useAllBones = options.useAllBones ?? true;
 
-        const initialMeshBoneIndices = mesh.getVerticesData(VertexBuffer.MatricesIndicesKind);
-        const initialMeshBoneWeights = mesh.getVerticesData(VertexBuffer.MatricesWeightsKind);
         this._boneIndices = new Set();
 
         if (!options.useAllBones) {
+            const initialMeshBoneIndices = mesh.getVerticesData(VertexBuffer.MatricesIndicesKind);
+            const initialMeshBoneWeights = mesh.getVerticesData(VertexBuffer.MatricesWeightsKind);
+            
             if (initialMeshBoneIndices && initialMeshBoneWeights) {
                 for (let i = 0; i < initialMeshBoneIndices.length; ++i) {
                     const index = initialMeshBoneIndices[i],

--- a/packages/dev/core/src/Debug/skeletonViewer.ts
+++ b/packages/dev/core/src/Debug/skeletonViewer.ts
@@ -422,7 +422,7 @@ export class SkeletonViewer {
         if (!options.useAllBones) {
             const initialMeshBoneIndices = mesh.getVerticesData(VertexBuffer.MatricesIndicesKind);
             const initialMeshBoneWeights = mesh.getVerticesData(VertexBuffer.MatricesWeightsKind);
-            
+
             if (initialMeshBoneIndices && initialMeshBoneWeights) {
                 for (let i = 0; i < initialMeshBoneIndices.length; ++i) {
                     const index = initialMeshBoneIndices[i],

--- a/packages/dev/core/src/Debug/skeletonViewer.ts
+++ b/packages/dev/core/src/Debug/skeletonViewer.ts
@@ -416,13 +416,11 @@ export class SkeletonViewer {
         options.displayOptions.localAxesSize = options.displayOptions.localAxesSize ?? 0.075;
         options.computeBonesUsingShaders = options.computeBonesUsingShaders ?? true;
         options.useAllBones = options.useAllBones ?? true;
-
         this._boneIndices = new Set();
 
         if (!options.useAllBones) {
             const initialMeshBoneIndices = mesh.getVerticesData(VertexBuffer.MatricesIndicesKind);
             const initialMeshBoneWeights = mesh.getVerticesData(VertexBuffer.MatricesWeightsKind);
-
             if (initialMeshBoneIndices && initialMeshBoneWeights) {
                 for (let i = 0; i < initialMeshBoneIndices.length; ++i) {
                     const index = initialMeshBoneIndices[i],


### PR DESCRIPTION
Skip mesh operations when they are not required. This is a first step to render skeletons without meshes.